### PR TITLE
Fix comment frame updates in add_to_comments

### DIFF
--- a/djmusiccleaner/dj_music_cleaner.py
+++ b/djmusiccleaner/dj_music_cleaner.py
@@ -1197,9 +1197,10 @@ class DJMusicCleaner:
                 audio.add_tags()
             
             if 'COMM::eng' in audio:
-                current = str(audio['COMM::eng'])
-                if text not in current:  # Avoid duplicates
-                    audio['COMM::eng'] = COMM(encoding=3, lang='eng', desc='', text=current + "\n" + text)
+                current_comm = audio['COMM::eng']
+                current_text = current_comm.text[0] if current_comm.text else ""
+                if text not in current_text:  # Avoid duplicates
+                    current_comm.text[0] = f"{current_text}\n{text}" if current_text else text
             else:
                 audio['COMM::eng'] = COMM(encoding=3, lang='eng', desc='', text=text)
             audio.save()


### PR DESCRIPTION
## Summary
- prevent corruption when appending comments by extracting existing text instead of using `str()`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689601d990508329850e5ec5765d5712