### PR TITLE
Avoid comments for low-quality files in HQ-only mode

### DIFF
--- a/djmusiccleaner/dj_music_cleaner.py
+++ b/djmusiccleaner/dj_music_cleaner.py
@@ -188,6 +188,8 @@ class DJMusicCleaner:
             
             print(f"   🎧 Quality: {quality_message} ({bitrate_kbps}kbps, {sample_rate_khz}kHz)")
             
+            quality_text = f"QUALITY: {bitrate_kbps}kbps, {sample_rate_khz}kHz, {quality_rating}"
+
             quality_info = {
                 'bitrate_kbps': bitrate_kbps,
                 'sample_rate_khz': sample_rate_khz,
@@ -195,13 +197,10 @@ class DJMusicCleaner:
                 'channels': channels,
                 'encoding': getattr(info, 'encoding', 'Unknown'),
                 'is_high_quality': is_high_quality,
-                'quality_rating': quality_rating
+                'quality_rating': quality_rating,
+                'quality_text': quality_text
             }
-            
-            # Add quality tag to MP3 comments
-            quality_text = f"QUALITY: {bitrate_kbps}kbps, {sample_rate_khz}kHz, {quality_rating}"
-            self.add_to_comments(filepath, quality_text)
-            
+
             return quality_info
             
         except Exception as e:
@@ -1782,6 +1781,8 @@ class DJMusicCleaner:
                                     
                                 self.stats['quality_analyzed'] += 1
                                 file_info['changes'].append(f"Quality analyzed: {file_info['bitrate']}kbps @ {file_info['sample_rate']}kHz")
+                                if quality_info.get('quality_text') and (not high_quality_only or file_info['is_high_quality']):
+                                    self.add_to_comments(input_file, quality_info['quality_text'])
                         except Exception as e:
                             print(f"   ❌ Error analyzing quality: {e}")
                     


### PR DESCRIPTION
## Summary
- include quality tag text in analysis results instead of writing comments immediately
- only append quality comments when not skipping low-quality files in high-quality-only runs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896415c4d448329af33d28c66995aa4